### PR TITLE
fix: check directory before listdir

### DIFF
--- a/python/py_package/_vulkan_tricks.py
+++ b/python/py_package/_vulkan_tricks.py
@@ -53,7 +53,7 @@ def _ensure_egl_icd():
 
     # 10_nvidia.json is installed
     for d in ["/usr/share/glvnd/egl_vendor.d", "/etc/glvnd/egl_vendor.d"]:
-        if any(("nvidia" in f) for f in os.listdir(d)):
+        if os.path.isdir(d) and any(("nvidia" in f) for f in os.listdir(d)):
             return
 
     warn(


### PR DESCRIPTION
- function `_ensure_egl_icd()` crashes when calling `os.listdir()` on one of `["/usr/share/glvnd/egl_vendor.d", "/etc/glvnd/egl_vendor.d"]` paths if they do not exist
- checking with `os.path.isdir(d)` makes sure 1. the path exists and 2. the path is a directory 