### PR TITLE
Fix typo from Conacts to Contacts

### DIFF
--- a/python/py_package/utils/viewer/contact_window.py
+++ b/python/py_package/utils/viewer/contact_window.py
@@ -40,7 +40,7 @@ class ContactWindow(Plugin):
         scene = self.viewer.scene
 
         if self.ui_window is None:
-            self.ui_window = R.UIWindow().Label("Conacts").Pos(10, 10).Size(400, 400)
+            self.ui_window = R.UIWindow().Label("Contacts").Pos(10, 10).Size(400, 400)
 
         self.ui_window.remove_children()
         self.ui_window.append(R.UICheckbox().Label("Enabled").Bind(self, "enabled"))


### PR DESCRIPTION
Fix small typo in UI ("Conacts" => "Contacts")

![image](https://github.com/user-attachments/assets/2591eaf7-9ff2-45ff-ac29-5dc379c19306)
