### PR TITLE
Fix the windows wheel build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: |
-            3.11
+            3.12
       - name: Build wheels
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: |
           C:/msys64/usr/bin/wget.exe https://developer.download.nvidia.com/compute/cuda/12.6.0/network_installers/cuda_12.6.0_windows_network.exe
-          ./cuda_12.6.0_windows_network.exe -s cudart_12.6 nvcc_12.6 nvtx_12.6 curand_dev_12.6
+          ./cuda_12.6.0_windows_network.exe -s cudart_12.6 nvcc_12.6 nvtx_12.6 curand_dev_12.6 visual_studio_integration_12.6
       - uses: actions/setup-python@v5
         with:
           python-version: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, master, dev]
 
 env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true


### PR DESCRIPTION
https://github.com/haosulab/SAPIEN/actions/runs/16352950336/job/46416455632

Based on the latest build error report, we need to install visual_studio_integration_xx when installing the CUDA toolkit:

```
CMake Error at C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeDetermineCompilerId.cmake:614 (message):
  No CUDA toolset found.
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeDetermineCompilerId.cmake:8 (CMAKE_DETERMINE_COMPILER_ID_BUILD)
  C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeDetermineCompilerId.cmake:53 (__determine_compiler_id_test)
  C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeDetermineCUDACompiler.cmake:131 (CMAKE_DETERMINE_COMPILER_ID)
  CMakeLists.txt:5 (project)
```
```
./cuda_12.6.0_windows_network.exe -s cudart_12.6 nvcc_12.6 nvtx_12.6 curand_dev_12.6 visual_studio_integration_12.6
```

https://docs.nvidia.com/cuda/archive/12.9.1/cuda-installation-guide-microsoft-windows/index.html#install-the-cuda-software


This is the build report after the repair. Successfully built windows versions of 3.9 to 3.13 wheel:
https://github.com/Puiching-Memory/SAPIEN/actions/runs/16914609726

Run the test using the NVIDIA 4060TI Python=3.13:

<img width="1922" height="1125" alt="image" src="https://github.com/user-attachments/assets/002fdbe7-6232-466f-82b0-1d4c958aa83d" />

