### PR TITLE
fix: resolve multi-GPU device assignment bug

### DIFF
--- a/python/pybind/sapien.cpp
+++ b/python/pybind/sapien.cpp
@@ -329,7 +329,10 @@ Generator<int> init_sapien(py::module &m) {
 
              py::object obj = py::cast(newArray);
              auto as_tensor = py::module_::import("torch").attr("as_tensor");
-             return as_tensor("data"_a = obj, "device"_a = "cuda");
+
+             std::string device_str = array.cudaId >= 0 ? 
+                                 "cuda:" + std::to_string(array.cudaId) : "cuda";  
+             return as_tensor("data"_a = obj, "device"_a = device_str);
            })
 #ifdef SAPIEN_CUDA
       .def("jax",


### PR DESCRIPTION
Previously always used fixed device string 'cuda' without ID
This caused issues in multi-GPU environments as specific GPU assignment was ignored
Now correctly generates 'cuda:X' for specific GPU selection based on array.cudaId"