### PR TITLE
Remove pkg_resources as a dependency

### DIFF
--- a/python/py_package/__init__.py
+++ b/python/py_package/__init__.py
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import importlib.resources as resources
 from warnings import warn
 import os
+import sys
 from pathlib import Path
 import platform
 from .version import __version__
@@ -46,6 +46,11 @@ from .wrapper.renderer import SapienRenderer
 from .wrapper.actor_builder import ActorBuilder
 from .wrapper.articulation_builder import ArticulationBuilder
 from .wrapper.pinocchio_model import PinocchioModel
+
+if sys.version_info >= (3, 9):
+    import importlib.resources as resources
+else:
+    import importlib_resources as resources
 
 try:
     render.set_imgui_ini_filename(str(Path.home() / ".sapien" / "imgui.ini"))

--- a/python/py_package/__init__.py
+++ b/python/py_package/__init__.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import importlib.resources as resources
 from warnings import warn
-import pkg_resources
 import os
 from pathlib import Path
 import platform
@@ -47,12 +47,12 @@ from .wrapper.actor_builder import ActorBuilder
 from .wrapper.articulation_builder import ArticulationBuilder
 from .wrapper.pinocchio_model import PinocchioModel
 
-import pkg_resources
-
 try:
     render.set_imgui_ini_filename(str(Path.home() / ".sapien" / "imgui.ini"))
     pysapien.render._internal_set_shader_search_path(
-        pkg_resources.resource_filename("sapien", "vulkan_shader")
+        str(
+            resources.files("sapien") / "vulkan_shader"
+        )
     )
     render.set_viewer_shader_dir("default")
     render.set_camera_shader_dir("default")

--- a/python/py_package/__init__.pyi
+++ b/python/py_package/__init__.pyi
@@ -2,7 +2,6 @@ from __future__ import annotations
 from _warnings import warn
 import os as os
 from pathlib._local import Path
-import pkg_resources as pkg_resources
 import platform as platform
 from sapien.pysapien import Component
 from sapien.pysapien import CudaArray
@@ -33,6 +32,5 @@ from . import render
 from . import utils
 from . import version
 from . import wrapper
-__all__ = ['ActorBuilder', 'ArticulationBuilder', 'Component', 'CudaArray', 'Device', 'Engine', 'Entity', 'Path', 'PinocchioModel', 'Pose', 'SapienRenderer', 'Scene', 'SceneConfig', 'System', 'Widget', 'asset', 'internal_renderer', 'math', 'os', 'physx', 'pkg_resources', 'platform', 'profile', 'pysapien', 'pysapien_pinocchio', 'render', 'set_log_level', 'simsense', 'utils', 'version', 'warn', 'wrapper']
+__all__ = ['ActorBuilder', 'ArticulationBuilder', 'Component', 'CudaArray', 'Device', 'Engine', 'Entity', 'Path', 'PinocchioModel', 'Pose', 'SapienRenderer', 'Scene', 'SceneConfig', 'System', 'Widget', 'asset', 'internal_renderer', 'math', 'os', 'physx', 'platform', 'profile', 'pysapien', 'pysapien_pinocchio', 'render', 'set_log_level', 'simsense', 'utils', 'version', 'warn', 'wrapper']
 __version__: str = '3.0.0.dev20251208+67ae2a67'
-__warningregistry__: dict = {'version': 0, ('pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.', UserWarning, 18): True}

--- a/python/py_package/_vulkan_tricks.py
+++ b/python/py_package/_vulkan_tricks.py
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import pkg_resources
-from warnings import warn
-import platform
+import importlib.resources as resources
 import os
+import platform
+from warnings import warn
 
 
 def _ensure_libvulkan_linux():
@@ -30,8 +30,8 @@ def _ensure_libvulkan_linux():
             return
 
     # add our vulkan to LD_LIBRARY_PATH
-    vulkan_library_path = pkg_resources.resource_filename(
-        "sapien", "vulkan_library/libvulkan.so.1.3.224"
+    vulkan_library_path = str(
+        resources.files("sapien") / "vulkan_library/libvulkan.so.1.3.224"
     )
 
     warn("Failed to find system libvulkan. Fallback to SAPIEN builtin libvulkan.")
@@ -51,8 +51,8 @@ def _ensure_libvulkan_mac():
         if os.path.isfile(libPath):
             os.environ["SAPIEN_VULKAN_LIBRARY_PATH"] = libPath
             return
-    vulkan_library_path = pkg_resources.resource_filename(
-        "sapien", "vulkan_library/libvulkan.1.3.290.dylib"
+    vulkan_library_path = str(
+        resources.files("sapien") / "vulkan_library/libvulkan.1.3.290.dylib"
     )
 
     warn("Failed to find system libvulkan. Fallback to SAPIEN builtin libvulkan.")
@@ -73,8 +73,8 @@ def _ensure_vulkan_icd():
     warn(
         "Failed to find Vulkan ICD file. This is probably due to an incorrect or partial installation of the NVIDIA driver. SAPIEN will attempt to provide an ICD file anyway but it may not work."
     )
-    os.environ["VK_ICD_FILENAMES"] = pkg_resources.resource_filename(
-        "sapien", "vulkan_library/nvidia_icd.json"
+    os.environ["VK_ICD_FILENAMES"] = str(
+        resources.files("sapien") / "vulkan_library/nvidia_icd.json"
     )
 
 
@@ -96,8 +96,8 @@ def _ensure_egl_icd():
         "Failed to find glvnd ICD file. This is probably due to an incorrect or partial installation of the NVIDIA driver. SAPIEN will attempt to provide an ICD file anyway but it may not work."
     )
 
-    os.environ["__EGL_VENDOR_LIBRARY_FILENAMES"] = pkg_resources.resource_filename(
-        "sapien", "vulkan_library/10_nvidia.json"
+    os.environ["__EGL_VENDOR_LIBRARY_FILENAMES"] = str(
+        resources.files("sapien") / "vulkan_library/10_nvidia.json"
     )
 
 

--- a/python/py_package/_vulkan_tricks.py
+++ b/python/py_package/_vulkan_tricks.py
@@ -14,10 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import importlib.resources as resources
 import os
 import platform
+import sys
 from warnings import warn
+
+if sys.version_info >= (3, 9):
+    import importlib.resources as resources
+else:
+    import importlib_resources as resources
 
 
 def _ensure_libvulkan_linux():

--- a/python/py_package/utils/viewer/control_window.py
+++ b/python/py_package/utils/viewer/control_window.py
@@ -15,15 +15,12 @@
 # limitations under the License.
 #
 import os
-from pathlib import Path
-from typing import List
 
 import numpy as np
-import pkg_resources
 import sapien
 from sapien import internal_renderer as R
-from transforms3d.quaternions import mat2quat
 from transforms3d.euler import quat2euler
+from transforms3d.quaternions import mat2quat
 
 from .camera_control import ArcRotateCameraController, FPSCameraController
 from .plugin import Plugin, copy_to_clipboard

--- a/python/py_package/utils/viewer/render_window.py
+++ b/python/py_package/utils/viewer/render_window.py
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import importlib.resources as resources
 from pathlib import Path
 
 import numpy as np
-import pkg_resources
 import sapien
 from sapien import internal_renderer as R
 
@@ -156,18 +156,16 @@ class RenderOptionsWindow(Plugin):
         self.shader_types = []
 
         try:
-            all_shader_dir = Path(
-                pkg_resources.resource_filename("sapien", "vulkan_shader")
-            )
-
-            for f in all_shader_dir.iterdir():
-                if f.is_dir():
-                    if any("gbuffer.frag" in x.name for x in f.iterdir()):
-                        self.shader_list.append(f)
-                        self.shader_types.append("rast")
-                    if any("camera.rgen" in x.name for x in f.iterdir()):
-                        self.shader_list.append(f)
-                        self.shader_types.append("rt")
+            all_shader_dir_ref = resources.files("sapien") / "vulkan_shader"
+            with resources.as_file(all_shader_dir_ref) as all_shader_dir:
+                for f in all_shader_dir.iterdir():
+                    if f.is_dir():
+                        if any("gbuffer.frag" in x.name for x in f.iterdir()):
+                            self.shader_list.append(f)
+                            self.shader_types.append("rast")
+                        if any("camera.rgen" in x.name for x in f.iterdir()):
+                            self.shader_list.append(f)
+                            self.shader_types.append("rt")
 
         except Exception:
             pass

--- a/python/py_package/utils/viewer/render_window.py
+++ b/python/py_package/utils/viewer/render_window.py
@@ -160,16 +160,15 @@ class RenderOptionsWindow(Plugin):
         self.shader_types = []
 
         try:
-            all_shader_dir_ref = resources.files("sapien") / "vulkan_shader"
-            with resources.as_file(all_shader_dir_ref) as all_shader_dir:
-                for f in all_shader_dir.iterdir():
-                    if f.is_dir():
-                        if any("gbuffer.frag" in x.name for x in f.iterdir()):
-                            self.shader_list.append(f)
-                            self.shader_types.append("rast")
-                        if any("camera.rgen" in x.name for x in f.iterdir()):
-                            self.shader_list.append(f)
-                            self.shader_types.append("rt")
+            all_shader_dir = Path(str(resources.files("sapien") / "vulkan_shader"))
+            for f in all_shader_dir.iterdir():
+                if f.is_dir():
+                    if any("gbuffer.frag" in x.name for x in f.iterdir()):
+                        self.shader_list.append(f)
+                        self.shader_types.append("rast")
+                    if any("camera.rgen" in x.name for x in f.iterdir()):
+                        self.shader_list.append(f)
+                        self.shader_types.append("rt")
 
         except Exception:
             pass

--- a/python/py_package/utils/viewer/render_window.py
+++ b/python/py_package/utils/viewer/render_window.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import importlib.resources as resources
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -23,6 +23,10 @@ from sapien import internal_renderer as R
 
 from .plugin import Plugin
 
+if sys.version_info >= (3, 9):
+    import importlib.resources as resources
+else:
+    import importlib_resources as resources
 
 class RenderOptionsWindow(Plugin):
     def __init__(self):

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,3 +6,4 @@ networkx
 pyperclip
 opencv-python>=4.0
 setuptools
+importlib_resources


### PR DESCRIPTION
The `pkg_resources` module from `setuptools` have been deprecated and removed in python 3.12. It's still possible to use it downgrading `setuptools` to version 81.0.0, but a long term solution would be to replace it entirely

In this context, the goal of this PR is to replace the use of the `pkg_resources` along SAPIEN source code

In order to accomplish this goal, the recommended alternatives are [importlib.resources](https://docs.python.org/3.12/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3.12/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata))

The `importlib.resources` library provides a useful [migration guide](https://importlib-resources.readthedocs.io/en/latest/migration.html) in order to move away from `pkg_resources`, so the implementation is pretty straightforward

As SAPIEN aims to support python 3.8, it's also needed to perform a conditional import, as `importlib.resources` is only available for python 3.9 or newer