### PR TITLE
add explicit feedback for illegal operations in GPU mode 

### DIFF
--- a/src/physx/articulation.cpp
+++ b/src/physx/articulation.cpp
@@ -359,41 +359,41 @@ PhysxArticulation::getLinkIncomingJointForces() {
 }
 
 Pose PhysxArticulation::getRootPose() {
-  // if (getRoot()->isUsingDirectGPUAPI()) {
-  //   throw std::runtime_error("getting root pose is not supported in GPU simulation.");
-  // }
+  if (getRoot()->isUsingDirectGPUAPI()) {
+    logger::warn("getting root pose may yields unsynchronized CPU data in GPU simulation.");
+  }
   return PxTransformToPose(mPxArticulation->getRootGlobalPose());
 }
 Vec3 PhysxArticulation::getRootLinearVelocity() {
-  // if (getRoot()->isUsingDirectGPUAPI()) {
-  //   throw std::runtime_error("getting root velocity is not supported in GPU simulation.");
-  // }
+  if (getRoot()->isUsingDirectGPUAPI()) {
+    logger::warn("getting root linear velocity may yield unsynchronized CPU data in GPU simulation.");
+  }
   return PxVec3ToVec3(mPxArticulation->getRootLinearVelocity());
 }
 Vec3 PhysxArticulation::getRootAngularVelocity() {
-  // if (getRoot()->isUsingDirectGPUAPI()) {
-  //   throw std::runtime_error("getting root velocity is not supported in GPU simulation.");
-  // }
+  if (getRoot()->isUsingDirectGPUAPI()) {
+    logger::warn("getting root angular velocity may yield unsynchronized CPU data in GPU simulation.");
+  }
   return PxVec3ToVec3(mPxArticulation->getRootAngularVelocity());
 }
 
 void PhysxArticulation::setRootPose(Pose const &pose) {
-  // if (getRoot()->isUsingDirectGPUAPI()) {
-  //   throw std::runtime_error("setting root pose is not supported in GPU simulation.");
-  // }
+  if (getRoot()->isUsingDirectGPUAPI()) {
+    throw std::runtime_error("setting root pose is illegal in GPU simulation.");
+  }
   mPxArticulation->setRootGlobalPose(PoseToPxTransform(pose));
   syncPose();
 }
 void PhysxArticulation::setRootLinearVelocity(Vec3 const &v) {
-  // if (getRoot()->isUsingDirectGPUAPI()) {
-  //   throw std::runtime_error("setting root velocity is not supported in GPU simulation.");
-  // }
+  if (getRoot()->isUsingDirectGPUAPI()) {
+    throw std::runtime_error("setting root linear velocity is illegal in GPU simulation.");
+  }
   mPxArticulation->setRootLinearVelocity(Vec3ToPxVec3(v));
 }
 void PhysxArticulation::setRootAngularVelocity(Vec3 const &v) {
-  // if (getRoot()->isUsingDirectGPUAPI()) {
-  //   throw std::runtime_error("setting root angular is not supported in GPU simulation.");
-  // }
+  if (getRoot()->isUsingDirectGPUAPI()) {
+    throw std::runtime_error("setting root angular velocity is illegal in GPU simulation.");
+  }
   mPxArticulation->setRootAngularVelocity(Vec3ToPxVec3(v));
 }
 


### PR DESCRIPTION
Hi @fbxiang, regarding the issue mentioned in #292, I've made a simple fix. Note that PhysX also disallows setting root properties in GPU mode, so I think throwing an error (instead of silent ignore) is the right approach here. I've tested it locally in both GPU and CPU modes, and everything runs fine. Please feel free to test it further or let me know any suggestions for improvement.