### PR TITLE
Fix sibling URDF mimic multiplier relation

### DIFF
--- a/python/py_package/wrapper/articulation_builder.py
+++ b/python/py_package/wrapper/articulation_builder.py
@@ -182,8 +182,8 @@ class ArticulationBuilder:
                     root = joint.parent_link
                     articulation.create_fixed_tendon(
                         [root, joint.child_link, mimic_joint.child_link],
-                        [0, -multiplier, 1],
-                        [0, -1 / multiplier, 1],
+                        [0, 1, -multiplier],
+                        [0, 1, -1 / multiplier],
                         rest_length=offset,
                         stiffness=1e5,
                     )

--- a/unittest/test_physx/test_articulation.py
+++ b/unittest/test_physx/test_articulation.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -71,6 +72,56 @@ class TestArticulation(unittest.TestCase):
         q = [0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.3, 0.4, 0.5]
         robot.set_qf(q)
         self.assertTrue(np.allclose(robot.get_qf(), q))
+
+    def test_urdf_mimic_sibling_multiplier_offset(self):
+        inertial = (
+            '<inertial><mass value="0.1"/><origin xyz="0 0 0"/>'
+            '<inertia ixx="0.001" iyy="0.001" izz="0.001" ixy="0" ixz="0" iyz="0"/>'
+            "</inertial>"
+        )
+        limit = '<limit lower="-10" upper="10" effort="100" velocity="100"/>'
+        urdf = f"""<robot name="mimic_sibling">
+  <link name="base">{inertial}</link>
+  <link name="source_link">{inertial}</link>
+  <link name="follower_link">{inertial}</link>
+  <joint name="source" type="revolute">
+    <parent link="base"/><child link="source_link"/>
+    <axis xyz="0 0 1"/>{limit}
+  </joint>
+  <joint name="follower" type="revolute">
+    <parent link="base"/><child link="follower_link"/>
+    <axis xyz="0 0 1"/>{limit}
+    <mimic joint="source" multiplier="2.0" offset="0.1"/>
+  </joint>
+</robot>"""
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "mimic_sibling.urdf"
+            path.write_text(urdf)
+
+            scene = sapien.Scene()
+            scene.set_timestep(1 / 240)
+            loader = scene.create_urdf_loader()
+            loader.fix_root_link = True
+            robot = loader.load(str(path))
+
+            joints = {j.get_name(): j for j in robot.get_active_joints()}
+            joints["source"].set_drive_property(
+                stiffness=5000, damping=500, force_limit=100000
+            )
+            joints["source"].set_drive_target(0.4)
+            joints["follower"].set_drive_property(stiffness=0, damping=0, force_limit=0)
+            for _ in range(720):
+                scene.step()
+
+            qpos = {
+                j.get_name(): robot.get_qpos()[i]
+                for i, j in enumerate(robot.get_active_joints())
+            }
+            self.assertAlmostEqual(
+                qpos["follower"],
+                2.0 * qpos["source"] + 0.1,
+                delta=1e-3,
+            )
 
     def test_kinematics_dynamics(self):
         scene = sapien.Scene()


### PR DESCRIPTION
## Summary

Fix URDF `<mimic>` constraints for **sibling** joints with a non-unit multiplier or non-zero offset.

SAPIEN loads URDF `<mimic>` joints as fixed tendons (`python/py_package/wrapper/articulation_builder.py`). The two topology branches order their tendon links differently:

- **chain** (`joint mimics parent`): `[grandparent, source_child, follower_child]`
- **sibling** (`2 children mimic each other`): `[root, follower_child, source_child]`

but both reuse the same coefficient vector `[0, -multiplier, 1]`. Because the source-child and follower-child links sit in opposite positions, the `-multiplier` coefficient lands on the **source** in the chain case (correct) but on the **follower** in the sibling case (wrong). The sibling constraint therefore becomes

```text
q_source = multiplier * q_follower + offset
# i.e.  q_follower = (q_source - offset) / multiplier    <- inverted
```

instead of the intended URDF relation

```text
q_follower = multiplier * q_source + offset
```

For the common `multiplier=1, offset=0` case this is invisible, which is why it went unnoticed; but any non-unit ratio is inverted, and any non-zero offset is applied to the wrong joint. This PR changes the sibling coefficients to `[0, 1, -multiplier]` and the reciprocals to `[0, 1, -1 / multiplier]`, matching the URDF convention. The chain branch is already correct and is left unchanged.

## Test

Adds `test_urdf_mimic_sibling_multiplier_offset`: a minimal sibling-joint URDF with

```xml
<mimic joint="source" multiplier="2.0" offset="0.1"/>
```

drives `source` and asserts `q_follower ~= 2.0 * q_source + 0.1`. This **fails** on the current code (the follower instead satisfies the inverted `(q_source - 0.1) / 2`) and **passes** with the fix.

## Validation

Loaded the sibling URDF on a SAPIEN 3.0.3 wheel (drive `source` to 0.4, follower left free):

| build | source | follower | satisfies |
|---|---|---|---|
| before (current) | 0.3998 | 0.1499 | `(source - 0.1) / 2`  (inverted) |
| after (this PR)  | 0.3999 | 0.8998 | `2 * source + 0.1`  (URDF-correct) |

The chain topology satisfies `2 * source + 0.1` both before and after, confirming the fix is scoped to the sibling branch only.

_Note: the repo's GitHub workflow builds wheels but does not run `unittest/`, so the added regression test was run locally._

